### PR TITLE
ensure salt-minion package is installed before attempting to start service

### DIFF
--- a/manifests/minion.pp
+++ b/manifests/minion.pp
@@ -91,6 +91,9 @@ class salt::minion (
   Class['salt::minion::install']
   -> Class['salt::minion::config']
 
+  Class['salt::minion::install']
+  -> Class['salt::minion::service']
+
   Salt::Minion::Config::Create <| |>
   ~> Service["${salt::minion::service_name} service"]
 


### PR DESCRIPTION
Fixes a bug where Puppet might try to start the salt-minion service before installing the salt-minion package, if salt::minion::configs is undefined (which is the default).